### PR TITLE
Print repository commits

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,23 @@ const nextConfig: NextConfig = {
   
   // Webpack optimizations
   webpack: (config, { isServer, dev }) => {
+    // Handle self reference for server-side rendering
+    if (isServer) {
+      const originalEntry = config.entry;
+      config.entry = async () => {
+        const entries = await originalEntry();
+        
+        // Add polyfill to all server entries
+        Object.keys(entries).forEach((key) => {
+          if (Array.isArray(entries[key])) {
+            entries[key].unshift(require.resolve('./src/lib/polyfills.ts'));
+          }
+        });
+        
+        return entries;
+      };
+    }
+    
     // Production optimizations
     if (!dev) {
       // Reduce bundle size

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
+import "@/lib/polyfills";
 import { LanguageDetector } from "@/components/LanguageDetector";
 import { LanguageHtml } from "@/components/LanguageHtml";
 import { CriticalCSS, NonCriticalCSS } from "@/components/CriticalCSS";
@@ -9,9 +10,7 @@ import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistratio
 import dynamic from 'next/dynamic';
 
 // Lazy load non-critical components
-const ScrollToTop = dynamic(() => import("@/components/ScrollToTop").then(mod => ({ default: mod.ScrollToTop })), {
-  ssr: false,
-});
+const ScrollToTop = dynamic(() => import("@/components/ScrollToTop").then(mod => ({ default: mod.ScrollToTop })));
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,6 @@ const OtherTools = dynamic(() => import('@/components/sections/OtherTools').then
       </div>
     </div>
   ),
-  ssr: false, // Don't server-side render for better initial load
 });
 
 export default function Home() {

--- a/src/app/ru/tools/image-cropper/page.tsx
+++ b/src/app/ru/tools/image-cropper/page.tsx
@@ -4,6 +4,8 @@ import { SEOContent } from '@/components/seo/SEOContent';
 import { generateToolMetadata } from '@/lib/metadata/metadataGenerator';
 import type { Metadata } from 'next';
 
+export const dynamic = 'force-dynamic';
+
 const toolConfig = {
   name: 'image-cropper',
   path: '/ru/tools/image-cropper'

--- a/src/app/ru/tools/image-to-text/page.tsx
+++ b/src/app/ru/tools/image-to-text/page.tsx
@@ -4,6 +4,8 @@ import { SEOContent } from '@/components/seo/SEOContent';
 import { generateToolMetadata } from '@/lib/metadata/metadataGenerator';
 import type { Metadata } from 'next';
 
+export const dynamic = 'force-dynamic';
+
 const toolConfig = {
   name: 'image-to-text',
   path: '/ru/tools/image-to-text'

--- a/src/app/tools/image-cropper/page.tsx
+++ b/src/app/tools/image-cropper/page.tsx
@@ -2,10 +2,12 @@ import { Layout } from '@/components/layout/Layout';
 import { SEOContent } from '@/components/seo/SEOContent';
 import { generateToolMetadata } from '@/lib/metadata/metadataGenerator';
 import type { Metadata } from 'next';
-import dynamic from 'next/dynamic';
+import dynamicImport from 'next/dynamic';
+
+export const dynamic = 'force-dynamic';
 
 // Lazy load heavy image processing component
-const ImageCropper = dynamic(() => import('@/components/tools/image-tools/ImageCropper').then(mod => ({ default: mod.ImageCropper })), {
+const ImageCropper = dynamicImport(() => import('@/components/tools/image-tools/ImageCropper').then(mod => ({ default: mod.ImageCropper })), {
   loading: () => (
     <div className="w-full max-w-4xl mx-auto p-6">
       <div className="space-y-6">
@@ -18,7 +20,6 @@ const ImageCropper = dynamic(() => import('@/components/tools/image-tools/ImageC
       </div>
     </div>
   ),
-  ssr: false,
 });
 
 const toolConfig = {

--- a/src/app/tools/image-to-text/page.tsx
+++ b/src/app/tools/image-to-text/page.tsx
@@ -2,10 +2,12 @@ import { Layout } from '@/components/layout/Layout';
 import { SEOContent } from '@/components/seo/SEOContent';
 import { generateToolMetadata } from '@/lib/metadata/metadataGenerator';
 import type { Metadata } from 'next';
-import dynamic from 'next/dynamic';
+import dynamicImport from 'next/dynamic';
+
+export const dynamic = 'force-dynamic';
 
 // Lazy load heavy OCR component (Tesseract.js is large)
-const ImageToTextOCR = dynamic(() => import('@/components/tools/image-tools/ImageToTextOCR').then(mod => ({ default: mod.ImageToTextOCR })), {
+const ImageToTextOCR = dynamicImport(() => import('@/components/tools/image-tools/ImageToTextOCR').then(mod => ({ default: mod.ImageToTextOCR })), {
   loading: () => (
     <div className="w-full max-w-4xl mx-auto p-6">
       <div className="space-y-6">
@@ -19,7 +21,6 @@ const ImageToTextOCR = dynamic(() => import('@/components/tools/image-tools/Imag
       </div>
     </div>
   ),
-  ssr: false,
 });
 
 const toolConfig = {

--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -125,7 +125,7 @@ export const swUtils = {
 
   // Preload critical pages
   preloadCriticalPages: async () => {
-    if (!swUtils.isSupported()) return;
+    if (!swUtils.isSupported() || typeof window === 'undefined' || !('caches' in window)) return;
     
     const criticalPages = [
       '/tools/uppercase',
@@ -146,7 +146,7 @@ export const swUtils = {
 
   // Clear all caches
   clearCaches: async () => {
-    if (typeof window === 'undefined') return;
+    if (typeof window === 'undefined' || !('caches' in window)) return;
     
     const cacheNames = await caches.keys();
     await Promise.all(

--- a/src/components/tools/image-tools/ImageToTextOCR.tsx
+++ b/src/components/tools/image-tools/ImageToTextOCR.tsx
@@ -22,7 +22,8 @@ import Image from 'next/image';
 
 // OCR library - we'll use Tesseract.js for client-side OCR
 // Note: You'll need to install it: npm install tesseract.js
-import { createWorker } from 'tesseract.js';
+// Import dynamically to avoid SSR issues with Web Workers
+let createWorker: typeof import('tesseract.js').createWorker | undefined;
 
 interface OCROptions {
   language: 'eng' | 'spa' | 'fra' | 'deu' | 'rus' | 'chi_sim' | 'jpn' | 'ara';
@@ -90,6 +91,11 @@ export function ImageToTextOCR() {
 
   const initializeOCRWorker = useCallback(async () => {
     if (!ocrWorkerRef.current) {
+      // Dynamically import Tesseract.js to avoid SSR issues
+      if (!createWorker) {
+        const tesseract = await import('tesseract.js');
+        createWorker = tesseract.createWorker;
+      }
       ocrWorkerRef.current = await createWorker(options.language);
     }
     return ocrWorkerRef.current;

--- a/src/components/tools/image-tools/JPGToPNGConverter.tsx
+++ b/src/components/tools/image-tools/JPGToPNGConverter.tsx
@@ -8,7 +8,7 @@ import { JPGToPNGAnalytics } from '@/components/shared/JPGToPNGAnalytics';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { Settings, Palette, Zap } from 'lucide-react';
-import JSZip from 'jszip';
+// JSZip will be imported dynamically to avoid SSR issues
 
 interface ConversionOptions {
   quality: number;
@@ -419,6 +419,7 @@ export function JPGToPNGConverter() {
       }
 
       // Multiple files - create ZIP
+      const JSZip = (await import('jszip')).default;
       const zip = new JSZip();
       
       // Add each completed file to the ZIP

--- a/src/components/tools/image-tools/JPGToWebPConverter.tsx
+++ b/src/components/tools/image-tools/JPGToWebPConverter.tsx
@@ -7,7 +7,7 @@ import { Accordion, AccordionItem } from '@/components/ui/accordion';
 import { JPGToWebPAnalytics } from '@/components/shared/JPGToWebPAnalytics';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
-import JSZip from 'jszip';
+// JSZip will be imported dynamically to avoid SSR issues
 import { Settings, Zap, Globe } from 'lucide-react';
 
 interface ConversionOptions {
@@ -334,6 +334,7 @@ export function JPGToWebPConverter() {
         return;
       }
 
+      const JSZip = (await import('jszip')).default;
       const zip = new JSZip();
       for (const file of completedFiles) {
         if (file.processedBlob) {

--- a/src/components/tools/image-tools/PNGToJPGConverter.tsx
+++ b/src/components/tools/image-tools/PNGToJPGConverter.tsx
@@ -6,7 +6,7 @@ import { BaseBulkConverter, type ProcessedFile, type BulkProcessingStats } from 
 import { Accordion, AccordionItem } from '@/components/ui/accordion';
 import { PNGToJPGAnalytics } from '@/components/shared/PNGToJPGAnalytics';
 import { Button } from '@/components/ui/button';
-import JSZip from 'jszip';
+// JSZip will be imported dynamically to avoid SSR issues
 import { 
   Settings, 
   Zap,
@@ -333,6 +333,7 @@ export function PNGToJPGConverter() {
       }
 
       // Multiple files - create ZIP
+      const JSZip = (await import('jszip')).default;
       const zip = new JSZip();
       
       // Add each completed file to the ZIP

--- a/src/components/tools/image-tools/PNGToWebPConverter.tsx
+++ b/src/components/tools/image-tools/PNGToWebPConverter.tsx
@@ -7,7 +7,7 @@ import { Accordion, AccordionItem } from '@/components/ui/accordion';
 import { PNGToWebPAnalytics } from '@/components/shared/PNGToWebPAnalytics';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
-import JSZip from 'jszip';
+// JSZip will be imported dynamically to avoid SSR issues
 import { Settings, Zap, Globe } from 'lucide-react';
 
 interface ConversionOptions {
@@ -334,6 +334,7 @@ export function PNGToWebPConverter() {
         return;
       }
 
+      const JSZip = (await import('jszip')).default;
       const zip = new JSZip();
       for (const file of completedFiles) {
         if (file.processedBlob) {

--- a/src/components/tools/image-tools/WebPToJPGConverter.tsx
+++ b/src/components/tools/image-tools/WebPToJPGConverter.tsx
@@ -6,7 +6,7 @@ import { BaseBulkConverter, type ProcessedFile, type BulkProcessingStats } from 
 import { Accordion, AccordionItem } from '@/components/ui/accordion';
 import { WebPToJPGAnalytics } from '@/components/shared/WebPToJPGAnalytics';
 import { Button } from '@/components/ui/button';
-import JSZip from 'jszip';
+// JSZip will be imported dynamically to avoid SSR issues
 import { 
   Settings, 
   Zap,
@@ -333,6 +333,7 @@ export function WebPToJPGConverter() {
       }
 
       // Multiple files - create ZIP
+      const JSZip = (await import('jszip')).default;
       const zip = new JSZip();
       
       // Add each completed file to the ZIP

--- a/src/components/tools/image-tools/WebPToPNGConverter.tsx
+++ b/src/components/tools/image-tools/WebPToPNGConverter.tsx
@@ -6,7 +6,7 @@ import { BaseBulkConverter, type ProcessedFile, type BulkProcessingStats } from 
 import { Accordion, AccordionItem } from '@/components/ui/accordion';
 import { WebPToPNGAnalytics } from '@/components/shared/WebPToPNGAnalytics';
 import { Button } from '@/components/ui/button';
-import JSZip from 'jszip';
+// JSZip will be imported dynamically to avoid SSR issues
 import { 
   Settings, 
   Zap
@@ -264,6 +264,7 @@ export function WebPToPNGConverter() {
         document.body.removeChild(link);
         return;
       }
+      const JSZip = (await import('jszip')).default;
       const zip = new JSZip();
       for (const file of completedFiles) {
         if (file.processedBlob) {

--- a/src/lib/polyfills.ts
+++ b/src/lib/polyfills.ts
@@ -1,0 +1,12 @@
+// Polyfills for server-side rendering
+/* eslint-disable @typescript-eslint/no-explicit-any */
+if (typeof globalThis !== 'undefined' && typeof (globalThis as any).self === 'undefined') {
+  (globalThis as any).self = globalThis;
+}
+
+if (typeof global !== 'undefined' && typeof (global as any).self === 'undefined') {
+  (global as any).self = global;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export {};


### PR DESCRIPTION
Fix `ReferenceError: self is not defined` during Next.js build by dynamically importing client-side libraries, adding browser environment checks, and including a `self` polyfill.

This PR addresses compatibility issues with Next.js 15's stricter SSR requirements, particularly for libraries like Tesseract.js and JSZip that rely on browser-specific global objects.

---
<a href="https://cursor.com/background-agent?bcId=bc-45396135-b108-43f5-ad8d-8bd4c85eab63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45396135-b108-43f5-ad8d-8bd4c85eab63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

