### PR TITLE
Refine prompt for metadata explanation

### DIFF
--- a/refined_prompt.md
+++ b/refined_prompt.md
@@ -1,0 +1,41 @@
+# Website Metadata Analysis Request
+
+## Context
+This is a multilingual website (English and Russian). However, when searching on Yandex Russia in Russian, search results display English metadata (title tag and meta description) instead of Russian.
+
+## Request
+**Please analyze the codebase and explain:**
+
+1. **Why does Yandex show English metadata for Russian pages?**
+   - What is the root cause of this issue?
+   
+2. **What metadata currently exists?**
+   - Do we have Russian metadata defined anywhere?
+   - Do we have English metadata defined anywhere?
+   - Where are they located in the code?
+
+3. **Simple explanation with example**
+   - Explain the problem in simple terms
+   - Use a concrete example from the codebase to illustrate
+
+## Requirements
+- ✅ **Analysis only** - Do NOT make any code changes yet
+- ✅ **Facts only** - Base explanations strictly on what exists in the codebase
+- ✅ **No assumptions** - If something is uncertain, state it clearly
+- ✅ **Simple language** - Explain as if to someone learning about metadata
+- ✅ **Show evidence** - Include relevant code snippets or file locations
+
+## Expected Output Format
+
+### Problem Summary
+[Brief 2-3 sentence summary of the issue]
+
+### Current Metadata Status
+- **English metadata:** [Yes/No, where defined]
+- **Russian metadata:** [Yes/No, where defined]
+
+### Root Cause Analysis
+[Clear explanation with code examples]
+
+### Example Illustration
+[Concrete example showing the problem]


### PR DESCRIPTION
Add `refined_prompt.md` to provide a clearer and more structured prompt for analyzing a multilingual website's metadata issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-22e83076-fd77-418f-8ce9-a2906e8b7bdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22e83076-fd77-418f-8ce9-a2906e8b7bdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

